### PR TITLE
#1 - Remove empty select option on transactions page

### DIFF
--- a/src/ConcreteListTable.php
+++ b/src/ConcreteListTable.php
@@ -58,7 +58,6 @@ class ConcreteListTable extends WP_List_Table {
 					foreach ($this->filters as $filterSpec) {
 						echo "<select name='$filterSpec[key]'>";
 						echo "<option value=''>".htmlspecialchars($filterSpec["allLabel"])."</option>";
-						echo "<option></option>";
 						display_select_options($filterSpec["options"],$_REQUEST[$filterSpec["key"]]);
 						echo "</select>";
 					}


### PR DESCRIPTION
Fixes #1 

<table>
<tr>
<td style="vertical-align:top:">Before:
<br><br>
<img width="294" alt="#1 - before" src="https://user-images.githubusercontent.com/3323310/64060579-0e605400-cbf9-11e9-9c7f-33bf553acf38.png"></td>
<td style="vertical-align:top:">After:
<br><br>
<img width="290" alt="#1 - after" src="https://user-images.githubusercontent.com/3323310/64060580-128c7180-cbf9-11e9-99d1-b25a130625c0.png"></td>
</tr>
</table>

