### PR TITLE
#6: Remove empty select option on burn seeds page

### DIFF
--- a/tpl/seeds_burn.tpl.php
+++ b/tpl/seeds_burn.tpl.php
@@ -42,7 +42,6 @@
 				<td>
 					<select name="userId">
 						<option value="">Select User Account</option>
-						<option></option>
 						<?php foreach ($users as $user) { ?>
 							<option value="<?php echo $user["id"]; ?>"
 								<?php if ($userId==$user["id"]) echo "selected"; ?>


### PR DESCRIPTION
Fixes #6 

<table>
<tr>
<td>Before:
<br><br>
<img width="524" alt="#6 - before" src="https://user-images.githubusercontent.com/3323310/64061958-3fe21b00-cc0b-11e9-8fa1-23a061e8fd2c.png">

</td>
<td>After:
<br><br>
<img width="524" alt="#6 - after" src="https://user-images.githubusercontent.com/3323310/64061960-42dd0b80-cc0b-11e9-97b7-f6d0db9cc2f0.png">

</td>
</tr>
</table>