### PR TITLE
#9: Remove empty select option on new seeds transaction page

### DIFF
--- a/tpl/seeds_new_transaction.tpl.php
+++ b/tpl/seeds_new_transaction.tpl.php
@@ -20,7 +20,6 @@
 				<td>
 					<select name="fromUserId">
 						<option value="">Select User Account</option>
-						<option></option>
 						<?php display_select_options($userAccounts,$fromUserId); ?>
 					</select>
 					<p class="description">
@@ -35,7 +34,6 @@
 				<td>
 					<select name="toUserId">
 						<option value="">Select User Account</option>
-						<option></option>
 						<?php display_select_options($userAccounts,$toUserId); ?>
 					</select>
 					<p class="description">


### PR DESCRIPTION
Fixes #9 

<table>
<tr>
<td>Before:
<br><br>
<img width="623" alt="#9 before - 1" src="https://user-images.githubusercontent.com/3323310/64062032-62286880-cc0c-11e9-9d98-e49fc8d070c7.png">

<img width="622" alt="#9 before - 2" src="https://user-images.githubusercontent.com/3323310/64062033-65bbef80-cc0c-11e9-9d18-982746a8d4ba.png">

</td>
<td>After:
<br><br>
<img width="629" alt="#9 after - 1" src="https://user-images.githubusercontent.com/3323310/64062034-68b6e000-cc0c-11e9-9cd9-0ef4047d67c5.png">

<img width="617" alt="#9 after - 2" src="https://user-images.githubusercontent.com/3323310/64062036-6c4a6700-cc0c-11e9-9a23-dff070a0c047.png">

</td>
</tr>
</table>