### PR TITLE
#11: Integrate seed balance in user overview

### DIFF
--- a/wp-seeds.php
+++ b/wp-seeds.php
@@ -438,6 +438,66 @@ function seeds_send_sc( $args ) {
 	return render_template( __DIR__ . '/tpl/seeds_send.tpl.php', $vars );
 }
 
+/**
+ * Add custom colum header to accouts page
+ *
+ *  @package WordPress
+ *  @subpackage WP Seeds
+ *  @since 1.0
+ */
+add_filter('manage_users_columns', 'wps_manage_users_columns');
+function wps_manage_users_columns($columns) {
+	$new_columns = array(
+			'balance num'	=> __('Balance', 'wp-seeds'),
+	);
+	return array_merge($columns, $new_columns);
+}
+
+/**
+ * Add custom colum entry to accouts page
+ *
+ *  @package WordPress
+ *  @subpackage WP Seeds
+ *  @since 1.0
+ */
+add_action( 'manage_users_custom_column', 'wps_manage_users_custom_column', 10, 3 );
+function wps_manage_users_custom_column( $output, $column_name, $user_id ) {
+	global $wpdb;
+	switch ( $column_name ) {
+		case 'balance num':
+			return get_user_meta( $user_id, 'seeds_balance', true ) ?: '0';
+			break;
+	}
+}
+
+/**
+ * Make custom colum entry on accouts page sortable
+ *
+ *  @package WordPress
+ *  @subpackage WP Seeds
+ *  @since 1.0
+ */
+add_filter( 'manage_users_sortable_columns', 'wps_manage_users_sortable_columns' );
+function wps_manage_users_sortable_columns( $columns ) {
+	return wp_parse_args( array( 'balance num' => 'seeds_balance' ), $columns );
+}
+
+/**
+ * Add custom styles to dashboard
+ *
+ *  @package WordPress
+ *  @subpackage WP Seeds
+ *  @since 1.0
+ */
+add_action('admin_head', 'wps_admin_head');
+function wps_admin_head() {
+  echo '<style>
+	.fixed .column-balance {
+    width: 100px;
+	}
+  </style>';
+}
+
 // Register WordPress hooks.
 add_shortcode( 'seeds-balance', 'seeds_balance_sc' );
 add_shortcode( 'seeds-history', 'seeds_history_sc' );


### PR DESCRIPTION
Fixes #11 

<table>
<tr>
<td>Before:
<br><br>
<img width="921" alt="#11 - before" src="https://user-images.githubusercontent.com/3323310/64117738-3e912980-cd96-11e9-8bfe-a1a6140df202.png">

</td>
<td>After:
<br><br>

</td>
</tr>
</table>