### PR TITLE
#35: Allow users to create transaction request

### DIFF
--- a/tpl/wps-request-transaction-code.tpl.php
+++ b/tpl/wps-request-transaction-code.tpl.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * WP Seeds 🌱
+ *
+ * @package   wp-seeds
+ * @link      https://github.com/limikael/wp-seeds
+ * @author    Mikael Lindqvist & Niels Lange
+ * @copyright 2019 Mikael Lindqvist & Niels Lange
+ * @license   GPL v2 or later
+ */
+
+?>
+<div class="wrap">
+
+	<h1>Request Transaction</h1>
+
+	<?php if ( isset( $notice_success ) ) : ?>
+		<div class="notice notice-success is-dismissible">
+			<p><?php echo esc_html( $notice_success ); ?></p>
+		</div>
+	<?php endif; ?>
+
+	<?php printf( '<p><img src="https://chart.googleapis.com/chart?cht=qr&chs=300x300&chl=%s"></p>', esc_html( $qr_code_url ) ); ?>
+	
+</div>

--- a/tpl/wps-request-transaction-page.tpl.php
+++ b/tpl/wps-request-transaction-page.tpl.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * WP Seeds 🌱
+ *
+ * @package   wp-seeds
+ * @link      https://github.com/limikael/wp-seeds
+ * @author    Mikael Lindqvist & Niels Lange
+ * @copyright 2019 Mikael Lindqvist & Niels Lange
+ * @license   GPL v2 or later
+ */
+
+?>
+<div class="wrap">
+
+	<h1>Request Transaction</h1>
+
+	<?php if ( isset( $notice_success ) ) : ?>
+		<div class="notice notice-success is-dismissible">
+			<p><?php echo esc_html( $notice_success ); ?></p>
+		</div>
+	<?php endif; ?>
+
+	<?php if ( isset( $notice_error ) ) : ?>
+		<div class="notice notice-error is-dismissible">
+			<p><?php echo esc_html( $notice_error ); ?></p>
+		</div>
+	<?php endif; ?>
+
+	<form method="post" class="form-table" action="<?php echo esc_attr( $action ); ?>">
+		<table>
+			<tr>
+				<th scope="row">
+					<label>Amount</label>
+				</th>
+				<td>
+					<input type="number" class="regular-text" name="amount" value="<?php echo esc_attr( $amount ); ?>"/>
+					<p class="description">How many seeds do you want to request?</p>
+				</td>
+			</tr>
+		</table>
+		<p class="submit">
+			<input name="do_request" type="submit" class="button button-primary" value="Request transaction"/>
+		</p>
+	</form>
+	
+</div>


### PR DESCRIPTION
Fixes #35 

**Request for:**

![#35 - 1](https://user-images.githubusercontent.com/3323310/67021635-83003b00-f132-11e9-8259-05f01d2bda91.png)

**QR code with the requester USER_ID and the AMOUNT:**

![#35 - 2](https://user-images.githubusercontent.com/3323310/67021691-99a69200-f132-11e9-9509-31949673d3a4.png)

**Populated create transaction form when opening the QR code:**

![#35 - 3](https://user-images.githubusercontent.com/3323310/67021747-ad51f880-f132-11e9-85c5-5b761c89f40f.png)

⚠️ Please note that this feature cannot be tested locally, as the URL needs to be public accessible.
